### PR TITLE
Bump version to 9.1.5 for stable release

### DIFF
--- a/WarhammerCombatMathLibrary/WarhammerCombatMathLibrary/WarhammerCombatMathLibrary.csproj
+++ b/WarhammerCombatMathLibrary/WarhammerCombatMathLibrary/WarhammerCombatMathLibrary.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>WarhammerCombatMathLibrary</PackageId>
-    <Version>9.1.5-beta</Version>
+    <Version>9.1.5</Version>
     <Authors>Michael Logan</Authors>
     <Description>A set of library files used for calculating combat math for Warhammer 40k.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Updated the package version in WarhammerCombatMathLibrary.csproj from 9.1.5-beta to 9.1.5, marking the transition from beta to a stable release.